### PR TITLE
refactor: remove CortexMap project from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,32 +105,6 @@
       <img class="avatar" src="./assets/imgs/me_simple.png" alt="Sandipsinh Rathod" width="128" height="128">
     </div>
 
-    <section id="projects">
-      <h2>Projects</h2>
-
-      <div class="card">
-        <a href="./cortexmap/" style="text-decoration: none; color: inherit;">
-          <h3>CortexMap &mdash; AI-Powered Brain Atlas from Research Literature</h3>
-        </a>
-        <div class="card-meta">Penn State · Final Year Project · Spring 2026</div>
-        <div class="tags">
-          <span class="tag">Rust</span>
-          <span class="tag">PostgreSQL</span>
-          <span class="tag">RAG</span>
-          <span class="tag">pgvector</span>
-          <span class="tag">LLM</span>
-          <span class="tag">Distributed Systems</span>
-        </div>
-        <p class="card-desc">
-          Developing a distributed system that automatically generates comprehensive profiles for brain regions from thousands of neuroscience research papers. For each region—hippocampus, amygdala, prefrontal cortex—the system synthesizes their functions, associated diseases, and affected body parts, with every claim cited back to original research. Built with three Rust microservices to handle large-scale paper processing, relationship extraction, and profile generation. Processes 10K+ papers and 50K+ relationships to create an AI-powered brain atlas for neuroscience researchers.
-        </p>
-        <a href="https://github.com/CortexMap/cortexmap" target="_blank" rel="noopener" class="github-btn" onclick="event.stopPropagation();">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-          View on GitHub
-        </a>
-      </div>
-    </section>
-
     <section id="blog">
       <h2>Blog</h2>
 


### PR DESCRIPTION
## Summary
Removes the CortexMap project from the homepage's Projects section while keeping the standalone `/cortexmap/` page intact.

## Changes
- Removed the entire `<section id="projects">` block from `index.html`, including the CortexMap project card (heading, tags, description, and GitHub link).
- Since CortexMap was the only project listed, the empty "Projects" heading was removed as well to avoid an orphaned section.

## Preserved
- The `/cortexmap/` page (`cortexmap/index.html`) is untouched and remains directly accessible.
- All other homepage sections (About, Blog, Achievements, footer) are unchanged.